### PR TITLE
Support Windows key

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Non printable characters can be sent by specifying the keyname enclosed in brace
 * `{End}`
 * `{PgUp}`
 * `{PgDn}`
+* `{Windows}/{Win}`
 
 These keynames can also be combined with modifiers. For example `Send ^!{Delete}` sends the `CTRL+SHIFT+Delete` combination.
 

--- a/etherkey/usb-keyboard.ino
+++ b/etherkey/usb-keyboard.ino
@@ -167,6 +167,12 @@ uint16_t keyname_to_keycode(const char* keyname) {
     case str2int("pgdn"):
       keycode = KEY_PAGE_DOWN;
       break;
+    case str2int("Win"):
+    case str2int("win"):
+    case str2int("Windows"):
+    case str2int("windows"):
+      keycode = KEY_LEFT_GUI;
+      break;
   }
   return keycode;
 }


### PR DESCRIPTION
With {Win}/{Windows}. Arduino calls it the GUI key, and etherkey README calls it the WIN key. There are left and right variations. The left seems more common, and it doesn't seem to make much of a difference.